### PR TITLE
Pull Request for Payload Examples

### DIFF
--- a/Blower/examples/example-normalized.jsonld
+++ b/Blower/examples/example-normalized.jsonld
@@ -1,27 +1,25 @@
-[
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:Blower:Blower2",
-        "type": "Blower",
-        "name": {
-            "type": "Property",
-            "value": "Blower 2"
-        },
-        "description": {
-            "type": "Property",
-            "value": "Blower 2 providing aeration for wastewater treatment process."
-        },
-        "airflow": {
-            "type": "Property",
-            "value": 368.75
-        },
-        "https://uri.fiware.org/ns/data-models#energy": {
-            "type": "Property",
-            "value": 229.89
-        },
-        "https://uri.fiware.org/ns/data-models#pressure": {
-            "type": "Property",
-            "value": 84.06
-        }
-    }
-]
+{
+  "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+  "id": "urn:ngsi-ld:Blower:Blower2",
+  "type": "Blower",
+  "name": {
+    "type": "Property",
+    "value": "Blower 2"
+  },
+  "description": {
+    "type": "Property",
+    "value": "Blower 2 providing aeration for wastewater treatment process."
+  },
+  "airflow": {
+    "type": "Property",
+    "value": 368.75
+  },
+  "https://uri.fiware.org/ns/data-models#energy": {
+    "type": "Property",
+    "value": 229.89
+  },
+  "https://uri.fiware.org/ns/data-models#pressure": {
+    "type": "Property",
+    "value": 84.06
+  }
+}

--- a/Blower/examples/example-normalized.jsonld
+++ b/Blower/examples/example-normalized.jsonld
@@ -1,0 +1,27 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:Blower:Blower2",
+        "type": "Blower",
+        "name": {
+            "type": "Property",
+            "value": "Blower 2"
+        },
+        "description": {
+            "type": "Property",
+            "value": "Blower 2 providing aeration for wastewater treatment process."
+        },
+        "airflow": {
+            "type": "Property",
+            "value": 368.75
+        },
+        "https://uri.fiware.org/ns/data-models#energy": {
+            "type": "Property",
+            "value": 229.89
+        },
+        "https://uri.fiware.org/ns/data-models#pressure": {
+            "type": "Property",
+            "value": 84.06
+        }
+    }
+]

--- a/Blower/examples/example-normalized.jsonld
+++ b/Blower/examples/example-normalized.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+  "@context": "https://smartdatamodels.org/context.jsonld",
   "id": "urn:ngsi-ld:Blower:Blower2",
   "type": "Blower",
   "name": {

--- a/Blower/examples/example.jsonld
+++ b/Blower/examples/example.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+  "@context": "https://smartdatamodels.org/context.jsonld",
   "id": "urn:ngsi-ld:Blower:Blower2",
   "type": "Blower",
   "name": "Blower 2",

--- a/Blower/examples/example.jsonld
+++ b/Blower/examples/example.jsonld
@@ -1,0 +1,12 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:Blower:Blower2",
+        "type": "Blower",
+        "name": "Blower 2",
+        "description": "Blower 2 providing aeration for wastewater treatment process.",
+        "airflow": 368.75,
+        "https://uri.fiware.org/ns/data-models#energy": 229.89,
+        "https://uri.fiware.org/ns/data-models#pressure": 84.06
+    }
+]

--- a/Blower/examples/example.jsonld
+++ b/Blower/examples/example.jsonld
@@ -1,12 +1,10 @@
-[
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:Blower:Blower2",
-        "type": "Blower",
-        "name": "Blower 2",
-        "description": "Blower 2 providing aeration for wastewater treatment process.",
-        "airflow": 368.75,
-        "https://uri.fiware.org/ns/data-models#energy": 229.89,
-        "https://uri.fiware.org/ns/data-models#pressure": 84.06
-    }
-]
+{
+  "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+  "id": "urn:ngsi-ld:Blower:Blower2",
+  "type": "Blower",
+  "name": "Blower 2",
+  "description": "Blower 2 providing aeration for wastewater treatment process.",
+  "airflow": 368.75,
+  "energy": 229.89,
+  "pressure": 84.06
+}

--- a/OffGasStack/examples/example-normalized.jsonld
+++ b/OffGasStack/examples/example-normalized.jsonld
@@ -15,7 +15,7 @@
             "type": "Property",
             "value": 380
         },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/co2": {
+        "co2": {
             "type": "Property",
             "value": 1.8
         },
@@ -27,11 +27,11 @@
             "type": "Property",
             "value": 18.6
         },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": {
+        "startsAt": {
             "type": "Relationship",
             "object": "urn:ngsi-ld:WasteWaterJunction:junction3"
         },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": {
+        "endsAt": {
             "type": "Relationship",
             "object": "urn:ngsi-ld:WasteWaterJunction:junction4"
         }

--- a/OffGasStack/examples/example-normalized.jsonld
+++ b/OffGasStack/examples/example-normalized.jsonld
@@ -1,39 +1,37 @@
-[
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:OffGasStack:OffGasStack2",
-        "type": "OffGasStack",
-        "name": {
-            "type": "Property",
-            "value": "Off Gas Stack 2"
-        },
-        "description": {
-            "type": "Property",
-            "value": "Off gas stack from treatment lane 2."
-        },
-        "n2o": {
-            "type": "Property",
-            "value": 380
-        },
-        "co2": {
-            "type": "Property",
-            "value": 1.8
-        },
-        "ch4": {
-            "type": "Property",
-            "value": 35
-        },
-        "o2": {
-            "type": "Property",
-            "value": 18.6
-        },
-        "startsAt": {
-            "type": "Relationship",
-            "object": "urn:ngsi-ld:WasteWaterJunction:junction3"
-        },
-        "endsAt": {
-            "type": "Relationship",
-            "object": "urn:ngsi-ld:WasteWaterJunction:junction4"
-        }
-    }
-]
+{
+  "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+  "id": "urn:ngsi-ld:OffGasStack:OffGasStack2",
+  "type": "OffGasStack",
+  "name": {
+    "type": "Property",
+    "value": "Off Gas Stack 2"
+  },
+  "description": {
+    "type": "Property",
+    "value": "Off gas stack from treatment lane 2."
+  },
+  "n2o": {
+    "type": "Property",
+    "value": 380
+  },
+  "co2": {
+    "type": "Property",
+    "value": 1.8
+  },
+  "ch4": {
+    "type": "Property",
+    "value": 35
+  },
+  "o2": {
+    "type": "Property",
+    "value": 18.6
+  },
+  "startsAt": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:WasteWaterJunction:junction3"
+  },
+  "endsAt": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:WasteWaterJunction:junction4"
+  }
+}

--- a/OffGasStack/examples/example-normalized.jsonld
+++ b/OffGasStack/examples/example-normalized.jsonld
@@ -1,0 +1,39 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:OffGasStack:OffGasStack2",
+        "type": "OffGasStack",
+        "name": {
+            "type": "Property",
+            "value": "Off Gas Stack 2"
+        },
+        "description": {
+            "type": "Property",
+            "value": "Off gas stack from treatment lane 2."
+        },
+        "n2o": {
+            "type": "Property",
+            "value": 380
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/co2": {
+            "type": "Property",
+            "value": 1.8
+        },
+        "ch4": {
+            "type": "Property",
+            "value": 35
+        },
+        "o2": {
+            "type": "Property",
+            "value": 18.6
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:WasteWaterJunction:junction3"
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:WasteWaterJunction:junction4"
+        }
+    }
+]

--- a/OffGasStack/examples/example.jsonld
+++ b/OffGasStack/examples/example.jsonld
@@ -1,0 +1,15 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:OffGasStack:OffGasStack2",
+        "type": "OffGasStack",
+        "name": "Off Gas Stack 2",
+        "description": "Off gas stack from treatment lane 2.",
+        "n2o": 380,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/co2": 1.8,
+        "ch4": 35,
+        "o2": 18.6,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": "urn:ngsi-ld:WasteWaterJunction:junction3",
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": "urn:ngsi-ld:WasteWaterJunction:junction4"
+    }
+]

--- a/OffGasStack/examples/example.jsonld
+++ b/OffGasStack/examples/example.jsonld
@@ -1,15 +1,13 @@
-[
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:OffGasStack:OffGasStack2",
-        "type": "OffGasStack",
-        "name": "Off Gas Stack 2",
-        "description": "Off gas stack from treatment lane 2.",
-        "n2o": 380,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/co2": 1.8,
-        "ch4": 35,
-        "o2": 18.6,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": "urn:ngsi-ld:WasteWaterJunction:junction3",
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": "urn:ngsi-ld:WasteWaterJunction:junction4"
-    }
-]
+{
+  "@context": "https://smartdatamodels.org/context.jsonld",
+  "id": "urn:ngsi-ld:OffGasStack:OffGasStack2",
+  "type": "OffGasStack",
+  "name": "Off Gas Stack 2",
+  "description": "Off gas stack from treatment lane 2.",
+  "n2o": 380,
+  "co2": 1.8,
+  "ch4": 35,
+  "o2": 18.6,
+  "startsAt": "urn:ngsi-ld:WasteWaterJunction:junction3",
+  "endsAt": "urn:ngsi-ld:WasteWaterJunction:junction4"
+}

--- a/WasteWaterJunction/examples/example-normalized.jsonld
+++ b/WasteWaterJunction/examples/example-normalized.jsonld
@@ -1,0 +1,67 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:WasteWaterJunction:junction2",
+        "type": "WasteWaterJunction",
+        "name": {
+            "type": "Property",
+            "value": "Junction 2"
+        },
+        "description": {
+            "type": "Property",
+            "value": "A junction in the treatment lane representing a sampling location for the effluent wastewater."
+        },
+        "nh4": {
+            "type": "Property",
+            "value": 0.5
+        },
+        "no3": {
+            "type": "Property",
+            "value": 5.2
+        },
+        "do": {
+            "type": "Property",
+            "value": 1.2
+        },
+        "redox": {
+            "type": "Property",
+            "value": 250
+        },
+        "tn": {
+            "type": "Property",
+            "value": 7.18
+        },
+        "toc": {
+            "type": "Property",
+            "value": 16.28
+        },
+        "po4": {
+            "type": "Property",
+            "value": 0.29
+        },
+        "bod": {
+            "type": "Property",
+            "value": 2.44
+        },
+        "cod": {
+            "type": "Property",
+            "value": 36.6
+        },
+        "flowrate": {
+            "type": "Property",
+            "value": 27650
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": {
+            "type": "Property",
+            "value": 16
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": {
+            "type": "Property",
+            "value": 7.8
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
+        }
+    }
+]

--- a/WasteWaterJunction/examples/example-normalized.jsonld
+++ b/WasteWaterJunction/examples/example-normalized.jsonld
@@ -1,67 +1,67 @@
 [
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:WasteWaterJunction:junction2",
-        "type": "WasteWaterJunction",
-        "name": {
-            "type": "Property",
-            "value": "Junction 2"
-        },
-        "description": {
-            "type": "Property",
-            "value": "A junction in the treatment lane representing a sampling location for the effluent wastewater."
-        },
-        "nh4": {
-            "type": "Property",
-            "value": 0.5
-        },
-        "no3": {
-            "type": "Property",
-            "value": 5.2
-        },
-        "do": {
-            "type": "Property",
-            "value": 1.2
-        },
-        "redox": {
-            "type": "Property",
-            "value": 250
-        },
-        "tn": {
-            "type": "Property",
-            "value": 7.18
-        },
-        "toc": {
-            "type": "Property",
-            "value": 16.28
-        },
-        "po4": {
-            "type": "Property",
-            "value": 0.29
-        },
-        "bod": {
-            "type": "Property",
-            "value": 2.44
-        },
-        "cod": {
-            "type": "Property",
-            "value": 36.6
-        },
-        "flowrate": {
-            "type": "Property",
-            "value": 27650
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": {
-            "type": "Property",
-            "value": 16
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": {
-            "type": "Property",
-            "value": 7.8
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": {
-            "type": "Relationship",
-            "object": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
-        }
+  {
+    "@context": "https://smartdatamodels.org/context.jsonld",
+    "id": "urn:ngsi-ld:WasteWaterJunction:junction2",
+    "type": "WasteWaterJunction",
+    "name": {
+      "type": "Property",
+      "value": "Junction 2"
+    },
+    "description": {
+      "type": "Property",
+      "value": "A junction in the treatment lane representing a sampling location for the effluent wastewater."
+    },
+    "nh4": {
+      "type": "Property",
+      "value": 0.5
+    },
+    "no3": {
+      "type": "Property",
+      "value": 5.2
+    },
+    "do": {
+      "type": "Property",
+      "value": 1.2
+    },
+    "redox": {
+      "type": "Property",
+      "value": 250
+    },
+    "tn": {
+      "type": "Property",
+      "value": 7.18
+    },
+    "toc": {
+      "type": "Property",
+      "value": 16.28
+    },
+    "po4": {
+      "type": "Property",
+      "value": 0.29
+    },
+    "bod": {
+      "type": "Property",
+      "value": 2.44
+    },
+    "cod": {
+      "type": "Property",
+      "value": 36.6
+    },
+    "flowrate": {
+      "type": "Property",
+      "value": 27650
+    },
+    "temperature": {
+      "type": "Property",
+      "value": 16
+    },
+    "pH": {
+      "type": "Property",
+      "value": 7.8
+    },
+    "startsAt": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
     }
+  }
 ]

--- a/WasteWaterJunction/examples/example.jsonld
+++ b/WasteWaterJunction/examples/example.jsonld
@@ -1,22 +1,20 @@
-[
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:WasteWaterJunction:junction2",
-        "type": "WasteWaterJunction",
-        "name": "Junction 2",
-        "description": "A junction in the treatment lane representing a sampling location for the effluent wastewater.",
-        "nh4": 0.5,
-        "no3": 5.2,
-        "do": 1.2,
-        "redox": 250,
-        "tn": 7.18,
-        "toc": 16.28,
-        "po4": 0.29,
-        "bod": 2.44,
-        "cod": 36.6,
-        "flowrate": 27650,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": 16,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": 7.8,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
-    }
-]
+{
+  "@context": "https://smartdatamodels.org/context.jsonld",
+  "id": "urn:ngsi-ld:WasteWaterJunction:junction2",
+  "type": "WasteWaterJunction",
+  "name": "Junction 2",
+  "description": "A junction in the treatment lane representing a sampling location for the effluent wastewater.",
+  "nh4": 0.5,
+  "no3": 5.2,
+  "do": 1.2,
+  "redox": 250,
+  "tn": 7.18,
+  "toc": 16.28,
+  "po4": 0.29,
+  "bod": 2.44,
+  "cod": 36.6,
+  "flowrate": 27650,
+  "temperature": 16,
+  "pH": 7.8,
+  "startsAt": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
+}

--- a/WasteWaterJunction/examples/example.jsonld
+++ b/WasteWaterJunction/examples/example.jsonld
@@ -1,0 +1,22 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:WasteWaterJunction:junction2",
+        "type": "WasteWaterJunction",
+        "name": "Junction 2",
+        "description": "A junction in the treatment lane representing a sampling location for the effluent wastewater.",
+        "nh4": 0.5,
+        "no3": 5.2,
+        "do": 1.2,
+        "redox": 250,
+        "tn": 7.18,
+        "toc": 16.28,
+        "po4": 0.29,
+        "bod": 2.44,
+        "cod": 36.6,
+        "flowrate": 27650,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": 16,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": 7.8,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
+    }
+]

--- a/WasteWaterTank/examples/example-normalized.jsonld
+++ b/WasteWaterTank/examples/example-normalized.jsonld
@@ -1,55 +1,53 @@
-[
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:WasteWaterTank:aerobicTank2",
-        "type": "WasteWaterTank",
-        "name": {
-            "type": "Property",
-            "value": "Aerobic Tank 2"
-        },
-        "description": {
-            "type": "Property",
-            "value": "Aerobic tank in treatment lane 2."
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/tss": {
-            "type": "Property",
-            "value": 3500
-        },
-        "nh4": {
-            "type": "Property",
-            "value": 1.3
-        },
-        "no3": {
-            "type": "Property",
-            "value": 5.2
-        },
-        "do": {
-            "type": "Property",
-            "value": 1.2
-        },
-        "redox": {
-            "type": "Property",
-            "value": 250
-        },
-        "sludgeLevel": {
-            "type": "Property",
-            "value": 0.8
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": {
-            "type": "Property",
-            "value": 16
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": {
-            "type": "Property",
-            "value": 7.8
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": {
-            "type": "Relationship",
-            "object": "urn:ngsi-ld:WasteWaterTank:facultativeTank2"
-        },
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": {
-            "type": "Relationship",
-            "object": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
-        }
-    }
-]
+{
+  "@context": "https://smartdatamodels.org/context.jsonld",
+  "id": "urn:ngsi-ld:WasteWaterTank:aerobicTank2",
+  "type": "WasteWaterTank",
+  "name": {
+    "type": "Property",
+    "value": "Aerobic Tank 2"
+  },
+  "description": {
+    "type": "Property",
+    "value": "Aerobic tank in treatment lane 2."
+  },
+  "tss": {
+    "type": "Property",
+    "value": 3500
+  },
+  "nh4": {
+    "type": "Property",
+    "value": 1.3
+  },
+  "no3": {
+    "type": "Property",
+    "value": 5.2
+  },
+  "do": {
+    "type": "Property",
+    "value": 1.2
+  },
+  "redox": {
+    "type": "Property",
+    "value": 250
+  },
+  "sludgeLevel": {
+    "type": "Property",
+    "value": 0.8
+  },
+  "temperature": {
+    "type": "Property",
+    "value": 16
+  },
+  "pH": {
+    "type": "Property",
+    "value": 7.8
+  },
+  "startsAt": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:WasteWaterTank:facultativeTank2"
+  },
+  "endsAt": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
+  }
+}

--- a/WasteWaterTank/examples/example-normalized.jsonld
+++ b/WasteWaterTank/examples/example-normalized.jsonld
@@ -1,0 +1,55 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:WasteWaterTank:aerobicTank2",
+        "type": "WasteWaterTank",
+        "name": {
+            "type": "Property",
+            "value": "Aerobic Tank 2"
+        },
+        "description": {
+            "type": "Property",
+            "value": "Aerobic tank in treatment lane 2."
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/tss": {
+            "type": "Property",
+            "value": 3500
+        },
+        "nh4": {
+            "type": "Property",
+            "value": 1.3
+        },
+        "no3": {
+            "type": "Property",
+            "value": 5.2
+        },
+        "do": {
+            "type": "Property",
+            "value": 1.2
+        },
+        "redox": {
+            "type": "Property",
+            "value": 250
+        },
+        "sludgeLevel": {
+            "type": "Property",
+            "value": 0.8
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": {
+            "type": "Property",
+            "value": 16
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": {
+            "type": "Property",
+            "value": 7.8
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:WasteWaterTank:facultativeTank2"
+        },
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": {
+            "type": "Relationship",
+            "object": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
+        }
+    }
+]

--- a/WasteWaterTank/examples/example.jsonld
+++ b/WasteWaterTank/examples/example.jsonld
@@ -1,0 +1,19 @@
+[
+    {
+        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+        "id": "urn:ngsi-ld:WasteWaterTank:aerobicTank2",
+        "type": "WasteWaterTank",
+        "name": "Aerobic Tank 2",
+        "description": "Aerobic tank in treatment lane 2.",
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/tss": 3500,
+        "nh4": 1.3,
+        "no3": 5.2,
+        "do": 1.2,
+        "redox": 250,
+        "sludgeLevel": 0.8,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": 16,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": 7.8,
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": "urn:ngsi-ld:WasteWaterTank:facultativeTank2",
+        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
+    }
+]

--- a/WasteWaterTank/examples/example.jsonld
+++ b/WasteWaterTank/examples/example.jsonld
@@ -1,19 +1,17 @@
-[
-    {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
-        "id": "urn:ngsi-ld:WasteWaterTank:aerobicTank2",
-        "type": "WasteWaterTank",
-        "name": "Aerobic Tank 2",
-        "description": "Aerobic tank in treatment lane 2.",
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/tss": 3500,
-        "nh4": 1.3,
-        "no3": 5.2,
-        "do": 1.2,
-        "redox": 250,
-        "sludgeLevel": 0.8,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/temperature": 16,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/pH": 7.8,
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/startsAt": "urn:ngsi-ld:WasteWaterTank:facultativeTank2",
-        "https://smart-data-models.github.io/data-models/terms.jsonld#/definitions/endsAt": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
-    }
-]
+{
+  "@context": "https://smartdatamodels.org/context.jsonld",
+  "id": "urn:ngsi-ld:WasteWaterTank:aerobicTank2",
+  "type": "WasteWaterTank",
+  "name": "Aerobic Tank 2",
+  "description": "Aerobic tank in treatment lane 2.",
+  "tss": 3500,
+  "nh4": 1.3,
+  "no3": 5.2,
+  "do": 1.2,
+  "redox": 250,
+  "sludgeLevel": 0.8,
+  "temperature": 16,
+  "pH": 7.8,
+  "startsAt": "urn:ngsi-ld:WasteWaterTank:facultativeTank2",
+  "endsAt": "urn:ngsi-ld:WasteWaterTank:secondarySettler2a"
+}


### PR DESCRIPTION
Committing the payload examples for all 4 data models (total of 8) in NGSI-LD. 

I used the @context you provided (smartdatamodels.com..) in my payload and posted it to the context broker. However, whenever I would get the data back, it always took the ETSI @context and led to not recognizing some property names. I am unsure of the problem here with that!

Hope this is a good starting point or is already enough! :) 